### PR TITLE
Potential fix for code scanning alert no. 4: URL redirection from remote source

### DIFF
--- a/src/routes/routes_libros.py
+++ b/src/routes/routes_libros.py
@@ -327,11 +327,11 @@ def importar_datos():
     if request.method == "POST":
         if "file" not in request.files:
             flash("No se seleccionó ningún archivo.", "danger")
-            return redirect(request.url)
+            return redirect(url_for("libros.importar_datos"))
         file = request.files["file"]
         if file.filename == "":
             flash("No se seleccionó ningún archivo.", "danger")
-            return redirect(request.url)
+            return redirect(url_for("libros.importar_datos"))
         if file and allowed_file(file.filename):
             filename = secure_filename(file.filename)
             filepath = os.path.join(UPLOAD_FOLDER, filename)


### PR DESCRIPTION
Potential fix for [https://github.com/guizafj/Gestion_de_una_Biblioteca/security/code-scanning/4](https://github.com/guizafj/Gestion_de_una_Biblioteca/security/code-scanning/4)

La forma correcta de arreglarlo es **evitar redirigir a una URL derivada de la request** y usar en su lugar una ruta interna conocida de la aplicación.

Mejor cambio sin alterar funcionalidad: en `src/routes/routes_libros.py`, dentro de `importar_datos`, reemplazar ambos `return redirect(request.url)` por `return redirect(url_for("libros.importar_datos"))`.  
Así se mantiene el comportamiento esperado (“volver a la pantalla de importación” cuando falta archivo), pero eliminando la dependencia de datos potencialmente manipulables por el usuario.

No hacen falta nuevos métodos ni imports: `url_for` ya está importado en la línea 12.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
